### PR TITLE
Update the vitejs/plugin-vue version to match vitejs to resolve confl…

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   },
   "devDependencies": {
     "@rushstack/eslint-patch": "^1.1.0",
-    "@vitejs/plugin-vue": "^2.3.3",
+    "@vitejs/plugin-vue": "^5.0.5",
     "@vue/eslint-config-prettier": "^7.0.0",
     "autoprefixer": "^10.4.7",
     "eslint-plugin-vue": "^9.0.0",


### PR DESCRIPTION
Update the vitejs/plugin-vue version to match vitejs to resolve conflicts

The original error was as follows(npm install ):

# npm resolution error report

While resolving: @vitejs/plugin-vue@2.3.4
Found: vite@5.0.10
node_modules/vite
  dev vite@"^5.0.10" from the root project

Could not resolve dependency:
peer vite@"^2.5.10" from @vitejs/plugin-vue@2.3.4
node_modules/@vitejs/plugin-vue
  dev @vitejs/plugin-vue@"^2.3.4" from the root project

Conflicting peer dependency: vite@2.9.18
node_modules/vite
  peer vite@"^2.5.10" from @vitejs/plugin-vue@2.3.4
  node_modules/@vitejs/plugin-vue
    dev @vitejs/plugin-vue@"^2.3.4" from the root project

Fix the upstream dependency conflict, or retry
this command with --force or --legacy-peer-deps
to accept an incorrect (and potentially broken) dependency resolution.